### PR TITLE
Minor fixes for #216 and #246

### DIFF
--- a/jstest/builder/builder.py
+++ b/jstest/builder/builder.py
@@ -46,7 +46,7 @@ def save_artifacts(modules):
             if 'dst' not in artifact:
                 continue
 
-            if not eval(artifact.get('condition', 'False')):
+            if not eval(artifact.get('condition', 'True')):
                 continue
 
             src = artifact.get('src')

--- a/jstest/builder/modules/iotjs.build.config
+++ b/jstest/builder/modules/iotjs.build.config
@@ -258,7 +258,7 @@
     },
     "artifacts": [
       {
-        "src": "%{tizen-iotjs-dir}/build/%{target}/%{build-type}/libs",
+        "src": "%{tizen-iotjs-dir}/build/%{target}/%{build-type}/lib",
         "dst": "%{build-dir}/libs"
       },
       {

--- a/jstest/builder/modules/jerryscript.build.config
+++ b/jstest/builder/modules/jerryscript.build.config
@@ -54,7 +54,7 @@
         "dst": "%{build-dir}/libs"
       },
       {
-        "src": "testsuite",
+        "src": "%{testsuite}",
         "dst": "%{build-dir}/tests"
       }
     ]
@@ -141,6 +141,10 @@
         "--profile=%{jerryscript}/jerry-core/profiles/minimal.profile"
       ],
       "conditional-options": [
+        {
+          "condition": "'%{build-type}' == 'debug'",
+          "args": ["--debug"]
+        },
         {
           "condition": "%{memstat}",
           "args": ["--mem-stats=ON", "--debug"]

--- a/jstest/testrunner/utils.py
+++ b/jstest/testrunner/utils.py
@@ -33,7 +33,7 @@ def read_test_files(env):
 
     for root, _, files in os.walk(testpath):
         # The name of the testset is always the folder name.
-        testset = utils.relpath(root, utils.abspath(utils.join(testpath, '..')))
+        testset = utils.relpath(root, utils.abspath(utils.join(testpath)))
 
         # Create a new testset entry if it doesn't exist.
         if testset not in testsets:


### PR DESCRIPTION
First fix: if there is no `condition` field, the default value **must be** `True` (to execute the copy code blow the `if` statement).
Second fix: `%{testsuite}` is a symbol for the system while the `testrunner` just a literal. 